### PR TITLE
feat/standard-response: Standardize error and success response

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,12 +1,16 @@
 import { Module, ValidationPipe } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
-import { APP_PIPE } from '@nestjs/core';
+import { APP_INTERCEPTOR, APP_PIPE } from '@nestjs/core';
 import * as Joi from 'joi';
 import { LoggerModule } from 'nestjs-pino';
 import appConfig from './config/app.config';
 import { ReviewsModule } from './reviews/reviews.module';
 import { KafkaModule } from './kafka/kafka.module';
 import { PrismaModule } from './prisma/prisma.module';
+import {
+  ErrorInterceptor,
+  ResponseInterceptor,
+} from './common/interceptors/response.interceptors';
 
 @Module({
   imports: [
@@ -38,6 +42,14 @@ import { PrismaModule } from './prisma/prisma.module';
     {
       provide: APP_PIPE,
       useClass: ValidationPipe,
+    },
+    {
+      provide: APP_INTERCEPTOR,
+      useClass: ResponseInterceptor,
+    },
+    {
+      provide: APP_INTERCEPTOR,
+      useClass: ErrorInterceptor,
     },
   ],
 })

--- a/src/common/dto/response.dto.ts
+++ b/src/common/dto/response.dto.ts
@@ -1,0 +1,11 @@
+// response.dto.ts
+export class SuccessResponseDto<T> {
+  statusCode: number;
+  data: T;
+}
+
+export class ErrorResponseDto {
+  statusCode: number;
+  message: string;
+}
+

--- a/src/common/interceptors/response.interceptors.ts
+++ b/src/common/interceptors/response.interceptors.ts
@@ -1,0 +1,53 @@
+import {
+  Injectable,
+  NestInterceptor,
+  ExecutionContext,
+  CallHandler,
+  HttpStatus,
+  HttpException,
+} from '@nestjs/common';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { SuccessResponseDto, ErrorResponseDto } from '../dto/response.dto';
+
+@Injectable()
+export class ResponseInterceptor<T>
+  implements NestInterceptor<T, SuccessResponseDto<T>>
+{
+  intercept(
+    context: ExecutionContext,
+    next: CallHandler,
+  ): Observable<SuccessResponseDto<T>> {
+    return next.handle().pipe(
+      map((data) => ({
+        statusCode: HttpStatus.OK,
+        data,
+      })),
+    );
+  }
+}
+
+@Injectable()
+export class ErrorInterceptor
+  implements NestInterceptor<Error, ErrorResponseDto>
+{
+  intercept(
+    context: ExecutionContext,
+    next: CallHandler,
+  ): Observable<ErrorResponseDto> {
+    return next.handle().pipe(
+      map((error) => {
+        const response = context.switchToHttp().getResponse();
+        const statusCode =
+          error instanceof HttpException
+            ? error.getStatus()
+            : HttpStatus.INTERNAL_SERVER_ERROR;
+
+        return {
+          statusCode,
+          message: error.message || 'Internal Server Error',
+        };
+      }),
+    );
+  }
+}


### PR DESCRIPTION
### Description
This Pull request will standardize the response format for all the APIs in the application. It uses `ResponseInterceptor` and `ErrorInterceptor` to intercept the responses and format them into the following interface:

```typescript
export class SuccessResponseDto<T> {
  statusCode: number;
  data: T;
}

export class ErrorResponseDto {
  statusCode: number;
  message: string;
}
```

### JIRA
N/A

### Related PRs:
- *Replace this line with other PR links that which this PR is dependent of.

### Definition of Done Checklist (All must be checked)
- [ ] One or more reviews requested
- [ ] Assigned to another dev for review
- [ ] Code linting with eslint
- [ ] Code prettify with prettier
- [ ] Unit tests updated
  - [ ] OR don't need to be updated
- [ ] Screenshot(s) provided
  - [ ] OR neither html nor styling changed
- [ ] Notified/Verified change is db schema
  - [ ] OR no changes in db schema
- [ ] The travis build should pass
- [ ] Locally test the code

### Definition of done for the reviewer
- [ ] Check if the business requirement is fulfilled
- [ ] Locally test if possible

### Additional Comments

### Schema if applicable
